### PR TITLE
feat: #1 Discord退出通知機能の実装

### DIFF
--- a/Discord_webhook/webhook_server.py
+++ b/Discord_webhook/webhook_server.py
@@ -57,5 +57,9 @@ async def on_voice_state_update(user, before, after):
             message = f"{after.channel.name}に{user.display_name}が参加しました"
             logger.info(message)
             send_line_message(message)
+        if before.channel is not None and before.channel.id == VOICE_CHANNEL_ID:
+            message = f"{before.channel.name}から{user.display_name}が退出しました"
+            logger.info(message)
+            send_line_message(message)
 
 client.run(DISCORD_TOKEN)


### PR DESCRIPTION
## 概要
Discord退出通知機能（#1）の実装です。

Fixes #1

## 修正内容
- ユーザーのボイスチャット状態が変更された際、監視対象のボイスチャンネルから退出した場合に、特定チャンネルへ通知する処理を追加